### PR TITLE
fix what() signature

### DIFF
--- a/src/parser/Parser.h
+++ b/src/parser/Parser.h
@@ -39,7 +39,7 @@ Label file grammar:
 class parse_error : public std::exception {
 
 public:
-	virtual char *what() {
+   const char * what() const noexcept override {
 		return (char *) "Parsing error!";
 	}
 };


### PR DESCRIPTION
Without this change at least some compilers with the included warning settings will fail